### PR TITLE
feat: Add Shamir secret sharing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,9 @@ This library provides cryptographic operations that are compatible with nilDB no
 |             +------------+------------------------------------+------------------------------------+
 |             | sum        | | additive secret sharing          | 32-bit signed integer              |
 |             |            | | (prime modulus 2^32 + 15)        |                                    |
+|             +------------+------------------------------------+------------------------------------+
+|             | redundancy | | Shamir secret sharing            | 32-bit signed integer              |
+|             |            | | (prime modulus 2^32 + 15)        |                                    |
 +-------------+------------+------------------------------------+------------------------------------+
 
 Installation and Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ license = {text = "MIT"}
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = [
+    "lagrange~=3.0",
     "bcl~=2.3",
     "pailliers~=0.1"
 ]

--- a/test/test_nilql.py
+++ b/test/test_nilql.py
@@ -12,9 +12,18 @@ import pytest
 
 import nilql
 
-from src.nilql.nilql import add_shamir_shares
-
 _SECRET_SHARED_SIGNED_INTEGER_MODULUS = (2 ** 32) + 15
+
+
+def _shamirs_add(shares1, shares2, prime=_SECRET_SHARED_SIGNED_INTEGER_MODULUS):
+    """
+    Adds two sets of shares pointwise, assuming they use the same x-values.
+    """
+    return [
+        [x1, (y1 + y2) % prime]
+        for (x1, y1), (x2, y2) in zip(shares1, shares2)
+        if x1 == x2
+    ]
 
 def to_hash_base64(output: Union[bytes, list[int]]) -> str:
     """
@@ -544,8 +553,8 @@ class TestSecureComputations(TestCase):
         (a0, b0, c0) = nilql.encrypt(sk, 123)
         (a1, b1, c1) = nilql.encrypt(sk, 456)
         (a2, b2, c2) = nilql.encrypt(sk, 789)
-        (a3, b3, c3) = add_shamir_shares(
-            add_shamir_shares([a0, b0, c0], [a1, b1, c1]),
+        (a3, b3, c3) = _shamirs_add(
+            _shamirs_add([a0, b0, c0], [a1, b1, c1]),
             [a2, b2, c2]
         )
         decrypted = nilql.decrypt(sk, [a3, b3, c3])

--- a/test/test_nilql.py
+++ b/test/test_nilql.py
@@ -12,6 +12,8 @@ import pytest
 
 import nilql
 
+from src.nilql.nilql import add_shamir_shares
+
 def to_hash_base64(output: Union[bytes, list[int]]) -> str:
     """
     Helper function for converting a large output from a test into a
@@ -126,6 +128,21 @@ class TestKeys(TestCase):
         )
         self.assertEqual(sk_from_json, sk)
 
+    def test_key_operations_for_redundancy_with_multiple_nodes(self):
+        """
+        Test key generate, dump, JSONify, and load for redundancy operation
+        with multiple nodes.
+        """
+        sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
+        sk_loaded = nilql.SecretKey.load(sk.dump())
+        self.assertTrue(isinstance(sk, nilql.SecretKey))
+        self.assertTrue(sk == sk_loaded)
+
+        sk_from_json = nilql.SecretKey.load(
+            json.loads(json.dumps(sk.dump()))
+        )
+        self.assertTrue(sk == sk_from_json)
+
     def test_key_from_seed_for_store_with_single_node(self):
         """
         Test key generation from seed for store operation with a single node.
@@ -196,6 +213,21 @@ class TestKeys(TestCase):
             'L8RiHNq2EUgt/fDOoUw9QK2NISeUkAkhxHHIPoHPZ84='
         )
         sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'sum': True})
+        self.assertNotEqual(
+            to_hash_base64(sk['material']),
+            'L8RiHNq2EUgt/fDOoUw9QK2NISeUkAkhxHHIPoHPZ84='
+        )
+
+    def test_key_from_seed_for_redundancy_with_multiple_nodes(self):
+        """
+        Test key generation from seed for redundancy operation with multiple nodes.
+        """
+        sk_from_seed = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True}, SEED)
+        self.assertEqual(
+            to_hash_base64(sk_from_seed['material']),
+            'L8RiHNq2EUgt/fDOoUw9QK2NISeUkAkhxHHIPoHPZ84='
+        )
+        sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
         self.assertNotEqual(
             to_hash_base64(sk['material']),
             'L8RiHNq2EUgt/fDOoUw9QK2NISeUkAkhxHHIPoHPZ84='
@@ -299,6 +331,26 @@ class TestFunctions(TestCase):
         decrypted = nilql.decrypt(sk, ciphertext)
         self.assertEqual(decrypted, plaintext)
 
+    def test_encrypt_decrypt_of_int_for_redundancy_multiple(self):
+        """
+        Test encryption and decryption for redundancy operation with multiple nodes.
+        """
+        sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
+        plaintext = 123
+        ciphertext = nilql.encrypt(sk, plaintext)
+        decrypted = nilql.decrypt(sk, ciphertext)
+        self.assertEqual(decrypted, plaintext)
+
+    def test_encrypt_decrypt_of_int_for_redundancy_with_one_failure_multiple(self):
+        """
+        Test encryption and decryption for redundancy operation with multiple nodes.
+        """
+        sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
+        plaintext = 123
+        ciphertext = nilql.encrypt(sk, plaintext)
+        decrypted = nilql.decrypt(sk, ciphertext[1:])
+        self.assertEqual(decrypted, plaintext)
+
 class TestCiphertextRepresentations(TestCase):
     """
     Tests of the portable representation of ciphertexts.
@@ -324,6 +376,18 @@ class TestCiphertextRepresentations(TestCase):
         ck = nilql.ClusterKey.generate(cluster, operations)
         plaintext = 123
         ciphertext = [456, 246, 4294967296 + 15 - 123 - 456]
+        decrypted = nilql.decrypt(ck, ciphertext)
+        self.assertEqual(decrypted, plaintext)
+
+    def test_ciphertext_representation_for_redundancy_with_multiple_nodes(self):
+        """
+        Test that ciphertext representation when storing in a multiple-node cluster.
+        """
+        cluster = {'nodes': [{}, {}, {}]}
+        operations = {'redundancy': True}
+        ck = nilql.ClusterKey.generate(cluster, operations)
+        plaintext = 123
+        ciphertext = [(1, 1382717699), (2, 2765435275), (3, 4148152851)]
         decrypted = nilql.decrypt(ck, ciphertext)
         self.assertEqual(decrypted, plaintext)
 
@@ -466,6 +530,21 @@ class TestSecureComputations(TestCase):
             (a0 + a1 + a2) % (2 ** 32 + 15),
             (b0 + b1 + b2) % (2 ** 32 + 15),
             (c0 + c1 + c2) % (2 ** 32 + 15)
+        )
+        decrypted = nilql.decrypt(sk, [a3, b3, c3])
+        self.assertEqual(decrypted, 123 + 456 + 789)
+
+    def test_workflow_for_secure_redundancy_sum_with_multiple_nodes(self):
+        """
+        Test secure summation workflow for a cluster that has multiple nodes.
+        """
+        sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
+        (a0, b0, c0) = nilql.encrypt(sk, 123)
+        (a1, b1, c1) = nilql.encrypt(sk, 456)
+        (a2, b2, c2) = nilql.encrypt(sk, 789)
+        (a3, b3, c3) = add_shamir_shares(
+            add_shamir_shares([a0, b0, c0], [a1, b1, c1]),
+            [a2, b2, c2]
         )
         decrypted = nilql.decrypt(sk, [a3, b3, c3])
         self.assertEqual(decrypted, 123 + 456 + 789)

--- a/test/test_nilql.py
+++ b/test/test_nilql.py
@@ -14,6 +14,8 @@ import nilql
 
 from src.nilql.nilql import add_shamir_shares
 
+_SECRET_SHARED_SIGNED_INTEGER_MODULUS = (2 ** 32) + 15
+
 def to_hash_base64(output: Union[bytes, list[int]]) -> str:
     """
     Helper function for converting a large output from a test into a
@@ -136,12 +138,12 @@ class TestKeys(TestCase):
         sk = nilql.SecretKey.generate({'nodes': [{}, {}, {}]}, {'redundancy': True})
         sk_loaded = nilql.SecretKey.load(sk.dump())
         self.assertTrue(isinstance(sk, nilql.SecretKey))
-        self.assertTrue(sk == sk_loaded)
+        self.assertEqual(sk_loaded, sk)
 
         sk_from_json = nilql.SecretKey.load(
             json.loads(json.dumps(sk.dump()))
         )
-        self.assertTrue(sk == sk_from_json)
+        self.assertEqual(sk_from_json, sk)
 
     def test_key_from_seed_for_store_with_single_node(self):
         """
@@ -387,7 +389,7 @@ class TestCiphertextRepresentations(TestCase):
         operations = {'redundancy': True}
         ck = nilql.ClusterKey.generate(cluster, operations)
         plaintext = 123
-        ciphertext = [(1, 1382717699), (2, 2765435275), (3, 4148152851)]
+        ciphertext = [[1, 1382717699], [2, 2765435275], [3, 4148152851]]
         decrypted = nilql.decrypt(ck, ciphertext)
         self.assertEqual(decrypted, plaintext)
 


### PR DESCRIPTION
Add Shamir secret sharing hidden behind the `redundancy` flag. Note that `redundancy` implies `sum`.

Note, builds on https://github.com/NillionNetwork/nilql-py/pull/1 so review in order.